### PR TITLE
Fix rate limit and pagination bugs

### DIFF
--- a/app.php
+++ b/app.php
@@ -26,7 +26,7 @@ if (!is_dir($cache_icons )) {
 }
 
 $username    = trim($_ENV['username']); // set inside workflow variables
-$token 	     = trim($_ENV['token']); // set inside workflow variables
+$token       = trim($_ENV['token']); // set inside workflow variables
 $starred_url = sprintf('https://api.github.com/users/%s/starred', $username);
 $cache_ttl   = (empty($_ENV['cache_ttl'])) ? 3600 * 24 : (int) $_ENV['cache_ttl']; // in seconds
 $query       = trim($argv[1]); // optional text search

--- a/app.php
+++ b/app.php
@@ -26,6 +26,7 @@ if (!is_dir($cache_icons )) {
 }
 
 $username    = trim($_ENV['username']); // set inside workflow variables
+$token 	     = trim($_ENV['token']); // set inside workflow variables
 $starred_url = sprintf('https://api.github.com/users/%s/starred', $username);
 $cache_ttl   = (empty($_ENV['cache_ttl'])) ? 3600 * 24 : (int) $_ENV['cache_ttl']; // in seconds
 $query       = trim($argv[1]); // optional text search
@@ -44,6 +45,7 @@ if (file_exists($cache_response) && filemtime($cache_response) > (time() - $cach
 	curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
 	curl_setopt($curl, CURLOPT_HEADER, true);
 	curl_setopt($curl, CURLOPT_USERAGENT, 'GitHub Stars Alfred workflow for: ' . $username );
+	curl_setopt($curl, CURLOPT_USERPWD, $username . ":" . $token);
 	$resp = curl_exec($curl);
 
 	$header_size = curl_getinfo($curl, CURLINFO_HEADER_SIZE);
@@ -54,7 +56,7 @@ if (file_exists($cache_response) && filemtime($cache_response) > (time() - $cach
 
 	// check if there are headers indication pagination
 	// => make multiple requests to fetch ALL the stars.
-	if (preg_match('/Link:.*([0-9]+)>; rel="last"/', $header, $m)) {
+	if (preg_match('/([0-9]+)>; rel="last"/', $header, $m)) {
 		$last_page = (int) $m[1];
 
 		for ($i = 2; $i <= $last_page; $i++) {


### PR DESCRIPTION
### Without auth token, the GIthub API rate limit was quickly reached

Basically I was trying to figure out why some of my starred repos were not showing up in the results so I hit the API limit quickly. I added an auth token and it stopped complaining.

### Regex was too greedy with the `.*`

I saw this bug because I have a lot of starred repos and my the API was paginating 66 pages of results. The script ran without error as it was pulling "6", which was matched as the last digit only, because of greedy a regex. I haven't coded in PHP in 15 years so maybe there is a way to make the match less greedy without removing the preceding `Link:.*` but I didn't know so I went with this.
